### PR TITLE
Short-circuit IP address check if current app is not restricted.

### DIFF
--- a/admin_ip_restrictor/middleware.py
+++ b/admin_ip_restrictor/middleware.py
@@ -77,13 +77,10 @@ class AdminIPRestrictorMiddleware(MiddlewareMixin):
         return client_ip
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if self.restrict_admin:
+        app_name = request.resolver_match.app_name
+        is_restricted_app = app_name in self.restricted_app_names
+        if self.restrict_admin and is_restricted_app:
             ip = self.get_ip(request)
-            app_name = request.resolver_match.app_name
-            is_restricted_app = app_name in self.restricted_app_names
-            conditions = (is_restricted_app, self.is_blocked(ip))
-
-            if all(conditions):
+            if self.is_blocked(ip):
                 raise Http404()
-
         return None


### PR DESCRIPTION
If the current app is not restricted, something as simple as making an API request on a private network to a non-restricted Django app can cause the request to fail.

This PR checks the current app first, and if it is not restricted, does not perform an IP check.

For our case, we were trying to restrict access to our admin pages only, but these checks were running and rejecting requests for other non-admin apps that we did not want to protect.

It is unintuitive to have the user set a whitelist of apps to restrict access to, only to perform some checks for all apps, and since this PR helps make the settings more intuitive, it seems like it will be generally helpful to merge this change into the main codebase.