### PR TITLE
remove install_requires for django < 3 & python_version <3.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 `Release history`_
 ##################
 
+2.2.1 - 10-05-2021
+==================
+* Remove install_requires for django < 3
+* Remove install_requires for python_version < 3.6.0
+
+
 2.2.0 - 06-10-2020
 ==================
 

--- a/admin_ip_restrictor/__init__.py
+++ b/admin_ip_restrictor/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (2, 2, 0)
+VERSION = (2, 2, 1)
 
 
 __version__ = '{major}.{minor}.{patch}'.format(

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,7 @@ with open(os.path.join(PROJECT_DIR, 'README.rst')) as readme:
 
 install_requires = [
     'django>=1.11,<4; python_version >= "3.6.0"',
-    'django-ipware>=2,<4; python_version >= "3.6.0"',
-    'django>=1.11,<3; python_version < "3.6.0"',
-    'django-ipware>=2,<3; python_version < "3.6.0"'
+    'django-ipware>=2,<4; python_version >= "3.6.0"'
 ]
 
 test_requires = [


### PR DESCRIPTION
 - [O] Changelog entry added
 - [O] Version number updated

I thought the part of checking Django and Python versions when doing pip install was redundant, so I removed it.